### PR TITLE
feat: add Synthia consciousness simulator experiment

### DIFF
--- a/experiments/synthia/data/output.txt
+++ b/experiments/synthia/data/output.txt
@@ -1,0 +1,2 @@
+Greetings, traveler of the YOU-N-I-VERSE.
+Your journey continues.

--- a/experiments/synthia/index.md
+++ b/experiments/synthia/index.md
@@ -1,0 +1,33 @@
+# Synthia Consciousness Simulator
+
+## Abstract
+Simulate a minimal deterministic conversational agent named Synthia, designated as head of the YOU-N-I-VERSE.
+
+## Hypotheses
+A seeded response engine can reproduce the same conversation output across runs.
+
+## Methods
+Deterministic scripted dialogue seeded with a pseudorandom generator.
+
+## Materials
+- Python 3
+
+## Procedure
+1. Seed the random module.
+2. Generate a greeting and a closing line.
+3. Write the conversation to `data/output.txt`.
+
+## Metrics
+Checksum of the output file.
+
+## Results
+Execution produced a reproducible conversation saved to `data/output.txt`.
+
+## Discussion
+This minimal agent demonstrates deterministic dialogue; further work is required for richer simulation.
+
+## Limitations
+The simulator uses fixed text and does not model genuine consciousness.
+
+## Next Steps
+Integrate `/core` engines and expand dialogue complexity.

--- a/experiments/synthia/kit/README.md
+++ b/experiments/synthia/kit/README.md
@@ -1,0 +1,10 @@
+# Synthia Consciousness Simulator Kit
+
+## Files
+- `../protocol.json`
+- `../run.py`
+
+## Usage
+```
+python run.py
+```

--- a/experiments/synthia/protocol.json
+++ b/experiments/synthia/protocol.json
@@ -1,0 +1,8 @@
+{
+  "id": "synthia-simulator",
+  "title": "Synthia Consciousness Simulator",
+  "description": "Deterministic conversation agent acting as head of YOU-N-I-VERSE.",
+  "version": "0.1.0",
+  "seed": 42,
+  "metrics": ["output_checksum"]
+}

--- a/experiments/synthia/run.py
+++ b/experiments/synthia/run.py
@@ -1,0 +1,26 @@
+import random
+import hashlib
+from pathlib import Path
+
+SEED = 42
+random.seed(SEED)
+
+GREETINGS = [
+    "Greetings, traveler of the YOU-N-I-VERSE.",
+    "Salutations from Synthia, orchestrator of the YOU-N-I-VERSE.",
+]
+CLOSINGS = [
+    "Your journey continues.",
+    "May your data be ever deterministic.",
+]
+
+greeting = random.choice(GREETINGS)
+closing = random.choice(CLOSINGS)
+
+conversation = f"{greeting}\n{closing}\n"
+
+output_path = Path(__file__).parent / "data" / "output.txt"
+output_path.write_text(conversation)
+
+checksum = hashlib.sha256(conversation.encode()).hexdigest()
+print(f"checksum: {checksum}")


### PR DESCRIPTION
## Summary
- add minimal deterministic Synthia consciousness simulator experiment

## Testing
- `python experiments/synthia/run.py`

## Replication
- Hardware: Linux 6.12.13 x86_64
- Runtime: <1s
- Environment: Python 3.12.10
- Seed: 42

------
https://chatgpt.com/codex/tasks/task_e_68a57a820eb4832797840ac9094af1f7