### PR TITLE
Add unified CLI assistant and fix builder imports

### DIFF
--- a/builder_engine.py
+++ b/builder_engine.py
@@ -2,10 +2,11 @@
 import os
 import logging
 import json
-from parser.spec_extractor import extract_specs
-from parser.layout_organizer import generate_layout
+from spec_extractor import extract_specs
+from layout_organizer import generate_layout
 from jinja2 import Environment, FileSystemLoader
 
+os.makedirs("logs", exist_ok=True)
 logging.basicConfig(filename="logs/builder.log", level=logging.INFO)
 
 def run_builder():

--- a/ultimate_assistant.py
+++ b/ultimate_assistant.py
@@ -1,0 +1,46 @@
+import argparse
+import json
+from builder_engine import run_builder
+from oracle import parse_punctuation, get_gate_line_info
+
+
+def handle_oracle(input_str: str) -> None:
+    """Decode punctuation and Gate.Line information from the provided input."""
+    result = {}
+    punct = parse_punctuation(input_str)
+    if punct:
+        result["punctuation"] = punct
+    if "." in input_str:
+        parts = input_str.split(".")
+        if len(parts) == 2 and parts[0].isdigit() and parts[1].isdigit():
+            gate, line = int(parts[0]), int(parts[1])
+            result["gate_line"] = get_gate_line_info(gate, line)
+    print(json.dumps(result, indent=2))
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Unified interface for builder engine and oracle tools"
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    oracle_parser = subparsers.add_parser(
+        "oracle", help="Decode punctuation or Gate.Line values"
+    )
+    oracle_parser.add_argument(
+        "input", help="Input string such as '22.3' or 'Psalm 23:1;'"
+    )
+
+    subparsers.add_parser(
+        "build", help="Run the builder engine to generate app layout"
+    )
+
+    args = parser.parse_args()
+    if args.command == "oracle":
+        handle_oracle(args.input)
+    elif args.command == "build":
+        run_builder()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Fix `builder_engine` imports to use local modules and ensure log directory exists
- Introduce `ultimate_assistant.py` CLI to run the builder engine or decode gate/line info via the oracle module

## Testing
- `python -m py_compile builder_engine.py ultimate_assistant.py`
- `python ultimate_assistant.py oracle 22.3`
- `python ultimate_assistant.py build`


------
https://chatgpt.com/codex/tasks/task_e_68a61d45d9f48327a85e41a384c44249