### PR TITLE
Add combined assistant script and fix builder imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,3 +36,12 @@
 1. **Install dependencies**
 ```bash
 pip install -r requirements.txt
+```
+
+2. **Use the combined assistant**
+```bash
+python ultimate_assistant.py decode "Psalm 23:1;"
+python ultimate_assistant.py build
+```
+
+`ultimate_assistant.py` wraps the existing `oracle` and `builder_engine` modules so you can decode punctuation or generate app layouts from a single entry point.

--- a/builder_engine.py
+++ b/builder_engine.py
@@ -2,11 +2,11 @@
 import os
 import logging
 import json
-from parser.spec_extractor import extract_specs
-from parser.layout_organizer import generate_layout
-from jinja2 import Environment, FileSystemLoader
+from spec_extractor import extract_specs
+from layout_organizer import generate_layout
 
-logging.basicConfig(filename="logs/builder.log", level=logging.INFO)
+os.makedirs("logs", exist_ok=True)
+logging.basicConfig(filename=os.path.join("logs", "builder.log"), level=logging.INFO)
 
 def run_builder():
     upload_dir = "uploads"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 fastapi==0.104.1
 uvicorn==0.24.0
 pydantic==2.5.0
+jinja2==3.1.2

--- a/ultimate_assistant.py
+++ b/ultimate_assistant.py
@@ -1,0 +1,42 @@
+import argparse
+import json
+
+import builder_engine
+from oracle import parse_punctuation, get_gate_line_info
+
+
+def handle_decode(text: str) -> None:
+    """Decode punctuation or Gate.Line information."""
+    punct_results = parse_punctuation(text)
+    if punct_results:
+        for symbol, meaning in punct_results.items():
+            print(f"{symbol} -> {meaning}")
+    if '.' in text:
+        try:
+            gate, line = map(int, text.split('.'))
+            info = get_gate_line_info(gate, line)
+            print(json.dumps(info, indent=2))
+        except ValueError:
+            print("Invalid Gate.Line format")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Ultimate AI assistant")
+    subparsers = parser.add_subparsers(dest="command")
+
+    decode_parser = subparsers.add_parser("decode", help="Decode punctuation or Gate.Line")
+    decode_parser.add_argument("text", help="Input text or Gate.Line like 22.3")
+
+    subparsers.add_parser("build", help="Run builder engine")
+
+    args = parser.parse_args()
+    if args.command == "decode":
+        handle_decode(args.text)
+    elif args.command == "build":
+        builder_engine.run_builder()
+    else:
+        parser.print_help()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- create `ultimate_assistant.py` exposing oracle decoding and builder engine from one CLI
- fix `builder_engine` imports and logging path
- document new assistant usage and add `jinja2` requirement

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile builder_engine.py oracle.py layout_organizer.py spec_extractor.py ultimate_assistant.py`

------
https://chatgpt.com/codex/tasks/task_e_68a61d45d9f48327a85e41a384c44249