### PR TITLE
Add Synthia assistant CLI and fix builder imports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+logs/

--- a/builder_engine.py
+++ b/builder_engine.py
@@ -2,10 +2,11 @@
 import os
 import logging
 import json
-from parser.spec_extractor import extract_specs
-from parser.layout_organizer import generate_layout
+from spec_extractor import extract_specs
+from layout_organizer import generate_layout
 from jinja2 import Environment, FileSystemLoader
 
+os.makedirs("logs", exist_ok=True)
 logging.basicConfig(filename="logs/builder.log", level=logging.INFO)
 
 def run_builder():

--- a/synthia_assistant.py
+++ b/synthia_assistant.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Command-line assistant that combines builder and oracle tools."""
+
+import argparse
+
+from builder_engine import run_builder
+from oracle import parse_punctuation, get_gate_line_info
+
+
+def cmd_build(_args: argparse.Namespace) -> None:
+    """Run the universe builder to process uploads and generate files."""
+    run_builder()
+    print("Builder run complete.")
+
+
+def cmd_decode(args: argparse.Namespace) -> None:
+    """Decode punctuation and optional gate.line information."""
+    results = parse_punctuation(args.text)
+    if results:
+        print("Punctuation decoding:")
+        for symbol, meaning in results.items():
+            print(f"  {symbol} -> {meaning}")
+    else:
+        print("No punctuation cues detected.")
+
+    if args.gate_line:
+        try:
+            gate_str, line_str = args.gate_line.split(".")
+            gate, line = int(gate_str), int(line_str)
+            info = get_gate_line_info(gate, line)
+            print("Gate.Line info:")
+            for key, value in info.items():
+                print(f"  {key}: {value}")
+        except ValueError:
+            print("Invalid gate.line format; expected 'gate.line'.")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Synthia multi-tool assistant")
+    subparsers = parser.add_subparsers(dest="command")
+
+    build = subparsers.add_parser("build", help="Run universe builder on uploads")
+    build.set_defaults(func=cmd_build)
+
+    decode = subparsers.add_parser("decode", help="Decode punctuation and gate.line")
+    decode.add_argument("text", help="Input text to analyse")
+    decode.add_argument("--gate-line", help="Gate.line specification like 22.3")
+    decode.set_defaults(func=cmd_decode)
+
+    return parser
+
+
+def main() -> None:
+    parser = build_parser()
+    args = parser.parse_args()
+    if hasattr(args, "func"):
+        args.func(args)
+    else:
+        parser.print_help()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- fix builder_engine imports and ensure logs directory exists
- add a command-line `synthia_assistant` tool combining builder and oracle
- add gitignore for temporary files

## Testing
- `python synthia_assistant.py --help`
- `python synthia_assistant.py decode "Psalm 23:1;" --gate-line 22.3`


------
https://chatgpt.com/codex/tasks/task_e_68a61d45d9f48327a85e41a384c44249