### PR TITLE
feat: allow custom builder directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,4 +43,6 @@ pip install -r requirements.txt
 python ultimate_assistant.py --help
 ```
 Use the `oracle` subcommand to decode punctuation or gate lines, and `build` to generate an app layout.
+The `build` command accepts optional `--uploads` and `--output` paths to control input specs and output directory.
+
 

--- a/ultimate_assistant.py
+++ b/ultimate_assistant.py
@@ -38,15 +38,21 @@ def main() -> None:
         "--gate-line", help="Explicit Gate.Line value like '22.3'"
     )
 
-    subparsers.add_parser(
+    build_parser = subparsers.add_parser(
         "build", help="Run the builder engine to generate app layout"
+    )
+    build_parser.add_argument(
+        "--uploads", default="uploads", help="Directory with spec files"
+    )
+    build_parser.add_argument(
+        "--output", default="generated_app", help="Directory for generated app"
     )
 
     args = parser.parse_args()
     if args.command == "oracle":
         handle_oracle(args.text, args.gate_line)
     elif args.command == "build":
-        run_builder()
+        run_builder(args.uploads, args.output)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- allow specifying upload and output paths for builder engine via CLI
- document new build command options in README

## Testing
- `python ultimate_assistant.py --help`
- `python ultimate_assistant.py build --help`
- `python ultimate_assistant.py build`
- `python ultimate_assistant.py oracle 'Psalm 23:1;'`


------
https://chatgpt.com/codex/tasks/task_e_68a63976a7848327ab19765df345b46a