### PR TITLE
Add FastAPI interface for builder and oracle

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,4 +45,12 @@ python ultimate_assistant.py --help
 Use the `oracle` subcommand to decode punctuation or gate lines, and `build` to generate an app layout.
 The `build` command accepts optional `--uploads` and `--output` paths to control input specs and output directory.
 
+3. **Start the web API**
+```bash
+uvicorn assistant_api:app --reload
+```
+The API exposes two endpoints:
+- `POST /build` — trigger the builder engine (fields: `uploads`, `output`)
+- `POST /oracle` — decode punctuation or Gate.Line values (fields: `text`, `gate_line`)
+
 

--- a/assistant_api.py
+++ b/assistant_api.py
@@ -1,0 +1,43 @@
+from fastapi import FastAPI
+from pydantic import BaseModel
+from typing import Optional
+
+from builder_engine import run_builder
+from oracle import parse_punctuation, get_gate_line_info
+
+app = FastAPI(title="Synthia Assistant")
+
+
+class BuildRequest(BaseModel):
+    """Parameters for invoking the builder engine."""
+    uploads: str = "uploads"
+    output: str = "generated_app"
+
+
+class OracleRequest(BaseModel):
+    """Payload for decoding punctuation and gate/line information."""
+    text: str
+    gate_line: Optional[str] = None
+
+
+@app.post("/build")
+def build(req: BuildRequest):
+    """Run the builder engine on the provided directories."""
+    return run_builder(req.uploads, req.output)
+
+
+@app.post("/oracle")
+def oracle(req: OracleRequest):
+    """Decode punctuation and optionally a specific Gate.Line."""
+    result = {}
+    punct = parse_punctuation(req.text)
+    if punct:
+        result["punctuation"] = punct
+
+    target = req.gate_line or req.text
+    if "." in target:
+        parts = target.split(".")
+        if len(parts) == 2 and parts[0].isdigit() and parts[1].isdigit():
+            result["gate_line"] = get_gate_line_info(int(parts[0]), int(parts[1]))
+
+    return result


### PR DESCRIPTION
## Summary
- expose builder and oracle tools via a FastAPI service
- document API usage in README

## Testing
- `python -m py_compile assistant_api.py`
- `python -m py_compile ultimate_assistant.py`
- `python -m py_compile synthia_assistant.py`
- `python -m py_compile builder_engine.py`
- `python -m py_compile oracle.py`


------
https://chatgpt.com/codex/tasks/task_e_68a6676c65e483279e3e1721bbfc3706