### PR TITLE
Add Cynthia API skeleton and mechanics brief

### DIFF
--- a/cynthia/__init__.py
+++ b/cynthia/__init__.py
@@ -1,0 +1,5 @@
+"""Cynthia assistant skeleton package."""
+
+from .core import tick
+
+__all__ = ["tick"]

--- a/cynthia/api.py
+++ b/cynthia/api.py
@@ -1,0 +1,69 @@
+"""Flask API exposing Cynthia's core endpoints.
+
+The routes mirror the minimal API surface described in the mechanics
+brief. All handlers call placeholder implementations from
+``cynthia.core`` so the server can run without external dependencies.
+"""
+
+from __future__ import annotations
+
+from flask import Flask, jsonify, request
+
+from . import core
+
+app = Flask(__name__)
+
+
+@app.post("/v1/resolve-field")
+def resolve_field() -> tuple[str, int]:
+    data = request.get_json(force=True)
+    ts = data.get("ts", "")
+    geo = data.get("geo", {})
+    user_profile_id = data.get("user_profile_id", "")
+    return jsonify(core.resolve_field(ts, geo, user_profile_id)), 200
+
+
+@app.post("/v1/infer")
+def infer() -> tuple[str, int]:
+    data = request.get_json(force=True)
+    prompts = data.get("prompts", [])
+    candidates = core.orchestrate_nodes(prompts)
+    return jsonify({"candidates": candidates}), 200
+
+
+@app.post("/v1/collapse")
+def collapse() -> tuple[str, int]:
+    data = request.get_json(force=True)
+    candidates = data.get("candidates", [])
+    field = data.get("field", {})
+    intent = data.get("intent", "")
+    constraints = data.get("constraints", {})
+    decision = core.collapse(candidates, field, intent, constraints)
+    return jsonify(decision), 200
+
+
+@app.post("/v1/act")
+def act() -> tuple[str, int]:
+    data = request.get_json(force=True)
+    text = data.get("text", "")
+    field = data.get("field", {})
+    mode = data.get("mode", "Soft")
+    processed = core.postprocess(text, field, mode)
+    actions = core.route_actions(processed, {"mode": mode})
+    return jsonify(actions), 200
+
+
+@app.post("/v1/memory/upsert")
+def memory_upsert() -> tuple[str, int]:
+    # Placeholder: a real implementation would persist data here.
+    return jsonify({"ok": True}), 200
+
+
+@app.post("/v1/lab/apply-patch")
+def lab_apply_patch() -> tuple[str, int]:
+    # Placeholder: builder mode would apply a patch and run tests.
+    return jsonify({"ok": True, "tests": []}), 200
+
+
+if __name__ == "__main__":
+    app.run(debug=True)

--- a/cynthia/core.py
+++ b/cynthia/core.py
@@ -1,0 +1,107 @@
+"""Core mechanics for the Cynthia assistant.
+
+This module provides placeholder implementations of the main
+processing stages described in the mechanics blueprint. Each function
+returns simplified structures so the overall dataflow can be exercised
+without external dependencies.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+
+def perceive(envelope: Dict[str, Any]) -> Dict[str, Any]:
+    """Normalize raw input into a conversation context."""
+    return {
+        "utterance": envelope.get("utterance", ""),
+        "ts": envelope.get("ts", ""),
+        "geo": envelope.get("geo", {}),
+        "intent": envelope.get("intent", "unknown"),
+        "constraints": envelope.get("constraints", {}),
+        "mode": envelope.get("mode", "Soft"),
+        "user_profile_id": envelope.get("user_profile_id", ""),
+    }
+
+
+def resolve_field(ts: str, geo: Dict[str, Any], user_profile_id: str) -> Dict[str, Any]:
+    """Compute Body/Mind/Heart field vectors (stub)."""
+    return {
+        "field_state": {
+            "body": {"zodiac": "tropical", "gates": [], "ctb": []},
+            "mind": {"zodiac": "sidereal", "gates": [], "ctb": []},
+            "heart": {"zodiac": "draconic", "gates": [], "ctb": []},
+        },
+        "aspects": [],
+        "phase": "unknown",
+        "confidence": 0.0,
+    }
+
+
+def compose_prompts(ctx: Dict[str, Any], field: Dict[str, Any]) -> List[str]:
+    """Build prompts for model nodes (stub)."""
+    return [ctx.get("utterance", "")]
+
+
+def orchestrate_nodes(prompts: List[str], timeout_ms: int = 1800) -> List[Dict[str, Any]]:
+    """Launch model nodes and gather candidate responses (stub)."""
+    return [
+        {
+            "node": "stub_node",
+            "text": "placeholder response",
+            "logprob": 0.0,
+            "checks": {"schema_ok": True, "claims_verified": 0.0},
+            "features": {"latency_ms": 0, "len": len(prompts[0]) if prompts else 0},
+        }
+    ]
+
+
+def collapse(
+    candidates: List[Dict[str, Any]],
+    field: Dict[str, Any],
+    intent: str,
+    constraints: Dict[str, Any],
+) -> Dict[str, Any]:
+    """Score candidates and select a winner (stub)."""
+    winner = candidates[0] if candidates else {"node": "none", "text": ""}
+    return {
+        "winner": winner["node"],
+        "text": winner.get("text", ""),
+        "scorecard": [{"node": winner.get("node", "none"), "score": 0.0}],
+        "merge": False,
+        "why": ["stubbed collapse"],
+    }
+
+
+def postprocess(text: str, field: Dict[str, Any], mode: str) -> str:
+    """Apply sentence generator rules (stub)."""
+    return text
+
+
+def route_actions(text: str, ctx: Dict[str, Any]) -> Dict[str, Any]:
+    """Route output to downstream channels (stub)."""
+    return {"voice": text, "avatar": None, "task": None}
+
+
+def learn(
+    envelope: Dict[str, Any],
+    field: Dict[str, Any],
+    candidates: List[Dict[str, Any]],
+    decision: Dict[str, Any],
+    actions: Dict[str, Any],
+) -> None:
+    """Persist interaction data for future learning (stub)."""
+    return None
+
+
+def tick(envelope: Dict[str, Any]) -> Dict[str, Any]:
+    """Run a single Cynthia cycle and return action directives."""
+    ctx = perceive(envelope)
+    field = resolve_field(ctx["ts"], ctx["geo"], ctx["user_profile_id"])
+    prompts = compose_prompts(ctx, field)
+    candidates = orchestrate_nodes(prompts)
+    decision = collapse(candidates, field, ctx.get("intent", ""), ctx.get("constraints", {}))
+    output_text = postprocess(decision["text"], field, ctx.get("mode", "Soft"))
+    actions = route_actions(output_text, ctx)
+    learn(envelope, field, candidates, decision, actions)
+    return actions

--- a/cynthia_mechanics_brief.html
+++ b/cynthia_mechanics_brief.html
@@ -1,0 +1,98 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width,initial-scale=1" />
+<title>Cynthia — Mechanics Brief</title>
+<style>
+  :root{--bg:#0b0f14;--ink:#e6eefb;--mut:#9fb3c8;--card:#0f1522;--acc:#7bcfff;--ok:#39d98a;--warn:#ffd166;}
+  *{box-sizing:border-box} body{margin:0;background:var(--bg);color:var(--ink);font:14px/1.6 ui-sans-serif,system-ui,Segoe UI,Roboto}
+  .wrap{max-width:980px;margin:0 auto;padding:28px}
+  h1,h2,h3{margin:16px 0 8px} h1{font-size:28px} h2{font-size:20px;color:var(--acc)} h3{font-size:16px;color:var(--mut)}
+  .card{background:var(--card);border:1px solid #1c2338;border-radius:14px;padding:16px;margin:12px 0}
+  code,pre{background:#0b1120;border:1px solid #111a2c;border-radius:10px;padding:12px;display:block;overflow:auto}
+  .grid{display:grid;gap:12px} .g2{grid-template-columns:repeat(2,minmax(0,1fr))}
+  .tag{display:inline-block;padding:2px 8px;border:1px solid #22314f;border-radius:999px;margin-right:6px;color:var(--mut)}
+  .ok{color:var(--ok)} .warn{color:var(--warn)} .badge{font-weight:700}
+</style>
+</head>
+<body>
+<div class="wrap">
+  <h1>Cynthia — Mechanics Brief</h1>
+  <div class="card"><span class="tag">Multi-node</span><span class="tag">Field-aware</span><span class="tag">Collapse Engine</span></div>
+
+  <h2>0) One-line mental model</h2>
+  <div class="card">Inputs → Normalize → <b>Field Resolver</b> (Mind/Body/Heart) → <b>Node Orchestrator</b> → <b>Collapse Engine</b> → <b>Action Layer</b> → Learn.</div>
+
+  <h2>1) Dataflow</h2>
+  <pre><code>User I/O ──► Perception ─┬─► Context ─┬─► Orchestrator ─┬─► Collapse ─┬─► Action
+Sensors/Ephemeris ────────┘             └─► Field Resolver   │             └─► Voice/Avatar/Tasks
+                                                           Candidate Set</code></pre>
+
+  <h2>2) Core loops</h2>
+  <div class="grid g2">
+    <div class="card"><h3>A. Perception</h3><p>Normalize input, detect intent, build Conversation State.</p></div>
+    <div class="card"><h3>B. Field Resolver</h3><p>Compute Body(Tropical), Mind(Sidereal), Heart(Draconic), aspects, CTB.</p></div>
+    <div class="card"><h3>C. Orchestrator</h3><p>3–9 nodes; field-weighted prompts; gather candidates.</p></div>
+    <div class="card"><h3>D. Collapse</h3><p>Score/merge; emit trace of why-winner.</p></div>
+    <div class="card"><h3>E. Action</h3><p>Strict field sentence → Voice/Avatar/Tasks/Mem.</p></div>
+    <div class="card"><h3>F. Learn</h3><p>Log, feedback, optional self-build patching.</p></div>
+  </div>
+
+  <h2>3) Collapse scoring</h2>
+  <pre><code>score = α*FieldRes + β*TaskFit + γ*Truth + δ*Format + ε*History - κ*RedFlags</code></pre>
+  <div class="card"><b>Defaults:</b> α=.30 β=.25 γ=.20 δ=.15 ε=.10 κ=.40 (tunable)</div>
+
+  <h2>4) Contracts</h2>
+  <h3>Input</h3>
+  <pre><code>{
+  "utterance":"draft my field sentence for today",
+  "ts":"2025-08-21T11:07:00-07:00","locale":"en-US",
+  "geo":{"lat":37.7749,"lon":-122.4194},"mode":"Soft",
+  "constraints":{"format":"strict_field_sentence","max_tokens":220}
+}</code></pre>
+  <h3>Field Resolver</h3>
+  <pre><code>{
+  "field_state":{
+    "body":{"zodiac":"tropical","gates":["38.4","39.2"],"ctb":[3,2,5]},
+    "mind":{"zodiac":"sidereal","gates":["62.5","57.1"],"ctb":[5,1,2]},
+    "heart":{"zodiac":"draconic","gates":["27.3","28.6"],"ctb":[2,6,1]}
+  },
+  "aspects":[{"pair":["Sun","Mars"],"type":"square","orb":1.2}],
+  "confidence":0.86
+}</code></pre>
+
+  <h2>5) Modules</h2>
+  <div class="card">
+    <ul>
+      <li>Perception: ASR, clean, intent</li>
+      <li>Field Resolver: Swiss Ephem + HD (3 zodiacs, gates, CTB, aspects)</li>
+      <li>Prompt Composer: field-weighted system/tool prompts</li>
+      <li>Node Orchestrator: local models first; timeouts</li>
+      <li>Collapse Engine: score/merge/trace</li>
+      <li>Sentence Generator: strict assigned language (gate.line, CTB, axis, house, element)</li>
+      <li>Action Layer: TTS, avatar state, tasks</li>
+      <li>Memory/Telemetry: features, audits</li>
+      <li>Self-Builder: code patches/tests</li>
+    </ul>
+  </div>
+
+  <h2>6) API (minimal)</h2>
+  <pre><code>POST /v1/resolve-field   → field_state
+POST /v1/infer           → candidates[]
+POST /v1/collapse        → decision
+POST /v1/act             → voice/avatar/task
+POST /v1/memory/upsert   → ok
+POST /v1/lab/apply-patch → ok, tests</code></pre>
+
+  <h2>7) Loop</h2>
+  <pre><code>tick → perceive → resolve_field → compose → orchestrate → collapse → postprocess → act → learn</code></pre>
+
+  <h2>8) Quality gates</h2>
+  <div class="card">
+    <span class="badge ok">Strict schema</span> · <span class="badge ok">Traceability</span> ·
+    <span class="badge ok">Fallbacks</span> · <span class="badge ok">Latency SLO</span>
+  </div>
+</div>
+</body>
+</html>

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1,0 +1,227 @@
+openapi: 3.0.0
+info:
+  title: Cynthia API
+  version: '0.1.0'
+paths:
+  /v1/resolve-field:
+    post:
+      summary: Compute Body, Mind, and Heart field vectors
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                ts:
+                  type: string
+                  format: date-time
+                geo:
+                  type: object
+                user_profile_id:
+                  type: string
+      responses:
+        '200':
+          description: Field resolver output
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FieldResolverOutput'
+  /v1/infer:
+    post:
+      summary: Run model nodes and gather candidate responses
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                prompts:
+                  type: array
+                  items:
+                    type: string
+      responses:
+        '200':
+          description: Candidate set
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  candidates:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/NodeCandidate'
+  /v1/collapse:
+    post:
+      summary: Score and select final response
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                candidates:
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/NodeCandidate'
+                field:
+                  $ref: '#/components/schemas/FieldResolverOutput'
+                intent:
+                  type: string
+                constraints:
+                  type: object
+      responses:
+        '200':
+          description: Collapse decision
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CollapseDecision'
+  /v1/act:
+    post:
+      summary: Route final text to downstream channels
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                text:
+                  type: string
+                field:
+                  $ref: '#/components/schemas/FieldResolverOutput'
+                mode:
+                  type: string
+      responses:
+        '200':
+          description: Action directives
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  voice:
+                    type: string
+                    nullable: true
+                  avatar:
+                    type: string
+                    nullable: true
+                  task:
+                    type: string
+                    nullable: true
+  /v1/memory/upsert:
+    post:
+      summary: Persist memory data
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+      responses:
+        '200':
+          description: Status
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+  /v1/lab/apply-patch:
+    post:
+      summary: Apply a code patch and run tests
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+      responses:
+        '200':
+          description: Patch result
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                  tests:
+                    type: array
+                    items:
+                      type: string
+components:
+  schemas:
+    FieldResolverOutput:
+      type: object
+      properties:
+        field_state:
+          type: object
+          properties:
+            body:
+              $ref: '#/components/schemas/FieldState'
+            mind:
+              $ref: '#/components/schemas/FieldState'
+            heart:
+              $ref: '#/components/schemas/FieldState'
+        aspects:
+          type: array
+          items:
+            type: object
+        phase:
+          type: string
+        confidence:
+          type: number
+    FieldState:
+      type: object
+      properties:
+        zodiac:
+          type: string
+        gates:
+          type: array
+          items:
+            type: string
+        ctb:
+          type: array
+          items:
+            type: integer
+    NodeCandidate:
+      type: object
+      properties:
+        node:
+          type: string
+        text:
+          type: string
+        logprob:
+          type: number
+        checks:
+          type: object
+        features:
+          type: object
+    CollapseDecision:
+      type: object
+      properties:
+        winner:
+          type: string
+        text:
+          type: string
+        scorecard:
+          type: array
+          items:
+            type: object
+            properties:
+              node:
+                type: string
+              score:
+                type: number
+        merge:
+          type: boolean
+        why:
+          type: array
+          items:
+            type: string


### PR DESCRIPTION
## Summary
- scaffold Flask API exposing Cynthia's core endpoints
- outline core processing stages and tick loop
- document API with an OpenAPI spec and portable HTML mechanics brief

## Testing
- `python -m py_compile cynthia/__init__.py cynthia/core.py cynthia/api.py`


------
https://chatgpt.com/codex/tasks/task_e_68a66d36c47c8327b4a04d30f4693f56