### PR TITLE
Unify assistant CLI and API with shared core

### DIFF
--- a/assistant_api.py
+++ b/assistant_api.py
@@ -2,8 +2,7 @@ from fastapi import FastAPI
 from pydantic import BaseModel
 from typing import Optional
 
-from builder_engine import run_builder
-from oracle import parse_punctuation, get_gate_line_info
+from assistant_core import build as core_build, decode
 
 app = FastAPI(title="Synthia Assistant")
 
@@ -23,21 +22,10 @@ class OracleRequest(BaseModel):
 @app.post("/build")
 def build(req: BuildRequest):
     """Run the builder engine on the provided directories."""
-    return run_builder(req.uploads, req.output)
+    return core_build(req.uploads, req.output)
 
 
 @app.post("/oracle")
 def oracle(req: OracleRequest):
     """Decode punctuation and optionally a specific Gate.Line."""
-    result = {}
-    punct = parse_punctuation(req.text)
-    if punct:
-        result["punctuation"] = punct
-
-    target = req.gate_line or req.text
-    if "." in target:
-        parts = target.split(".")
-        if len(parts) == 2 and parts[0].isdigit() and parts[1].isdigit():
-            result["gate_line"] = get_gate_line_info(int(parts[0]), int(parts[1]))
-
-    return result
+    return decode(req.text, req.gate_line)

--- a/assistant_core.py
+++ b/assistant_core.py
@@ -1,0 +1,27 @@
+"""Core logic shared by CLI and API for the Synthia assistant."""
+from __future__ import annotations
+
+from builder_engine import run_builder
+from oracle import parse_punctuation, get_gate_line_info
+
+
+def decode(text: str, gate_line: str | None = None) -> dict:
+    """Decode punctuation and optional Gate.Line information."""
+    result: dict = {}
+    punct = parse_punctuation(text)
+    if punct:
+        result["punctuation"] = punct
+
+    target = gate_line or text
+    if "." in target:
+        parts = target.split(".")
+        if len(parts) == 2 and parts[0].isdigit() and parts[1].isdigit():
+            gate, line = int(parts[0]), int(parts[1])
+            result["gate_line"] = get_gate_line_info(gate, line)
+
+    return result
+
+
+def build(uploads: str = "uploads", output: str = "generated_app"):
+    """Run the builder engine and return its summary."""
+    return run_builder(uploads, output)


### PR DESCRIPTION
## Summary
- factor out shared builder and oracle logic into `assistant_core`
- simplify API server to use the new core helpers
- extend CLI to run a FastAPI server via new `server` subcommand

## Testing
- `pip install -r requirements.txt`
- `python -m pytest`
- `python -m py_compile assistant_core.py assistant_api.py ultimate_assistant.py`
- `python ultimate_assistant.py --help`


------
https://chatgpt.com/codex/tasks/task_e_68a66bc22df08327a0a0077fe5c3eb24